### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can find the full guide for the iOS SDK [online](https://heroiclabs.com/docs
 To develop on the codebase you'll need:
 
 * [Xcode](https://developer.apple.com/xcode) The Xcode Editor.
-* [Cocoapods](http://cocoapods.org) Objective-C/Swift Dependency Manager
+* [CocoaPods](http://cocoapods.org) Objective-C/Swift Dependency Manager
 
 #### Setup
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
