### PR TITLE
Add Module Definition

### DIFF
--- a/Classes/HeroicLabs.h
+++ b/Classes/HeroicLabs.h
@@ -1,0 +1,47 @@
+/*
+ Copyright 2015-2016 Heroic Labs
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#ifndef HeroicLabs
+#define HeroicLabs
+
+#import <HeroicLabs/HLgzipRequestSerializer.h>
+#import <HeroicLabs/NSURLRequest+HLURLRequest.h>
+#import <HeroicLabs/HLHttpClient.h>
+#import <HeroicLabs/HLLeaderboard.h>
+#import <HeroicLabs/HLMatchChange.h>
+#import <HeroicLabs/HLRequestRetryHandlerProtocol.h>
+#import <HeroicLabs/HLGame.h>
+#import <HeroicLabs/HLSessionClient.h>
+#import <HeroicLabs/HLClient.h>
+#import <HeroicLabs/HLServer.h>
+#import <HeroicLabs/HLAchievement.h>
+#import <HeroicLabs/HLMatch.h>
+#import <HeroicLabs/HLPurchaseVerification.h>
+#import <HeroicLabs/NSData+GZIP.h>
+#import <HeroicLabs/HeroicLabs.h>
+#import <HeroicLabs/HLDefaultRequestRetryHandler.h>
+#import <HeroicLabs/HLMessage.h>
+#import <HeroicLabs/HLGameCenterCredentials.h>
+#import <HeroicLabs/HLNoRequestRetryHandler.h>
+#import <HeroicLabs/HLJSONSerialisableProtocol.h>
+#import <HeroicLabs/HLPing.h>
+#import <HeroicLabs/HLDatastoreObject.h>
+#import <HeroicLabs/HLSharedStorageSearchResults.h>
+#import <HeroicLabs/HLMatchTurn.h>
+#import <HeroicLabs/HLGamer.h>
+#import <HeroicLabs/HLLeaderboardRank.h>
+
+#endif

--- a/HeroicLabs.xcodeproj/project.pbxproj
+++ b/HeroicLabs.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		136035111D5E3371002AFF78 /* HeroicLabs.h in Headers */ = {isa = PBXBuildFile; fileRef = 136035101D5E3371002AFF78 /* HeroicLabs.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD3168D41D5604FF009935F3 /* HeroicLabs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD3168C91D5604FF009935F3 /* HeroicLabs.framework */; };
 		CD31691A1D5606ED009935F3 /* HeroicLabs-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = CD3168E81D5606ED009935F3 /* HeroicLabs-Prefix.pch */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD31691B1D5606ED009935F3 /* HLAchievement.h in Headers */ = {isa = PBXBuildFile; fileRef = CD3168E91D5606ED009935F3 /* HLAchievement.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -82,6 +83,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		136035101D5E3371002AFF78 /* HeroicLabs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HeroicLabs.h; sourceTree = "<group>"; };
 		CD3168C91D5604FF009935F3 /* HeroicLabs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HeroicLabs.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD3168D31D5604FF009935F3 /* HeroicLabsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HeroicLabsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD3168E81D5606ED009935F3 /* HeroicLabs-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "HeroicLabs-Prefix.pch"; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 		CD3168E71D5606ED009935F3 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				136035101D5E3371002AFF78 /* HeroicLabs.h */,
 				CD3168F91D5606ED009935F3 /* HLHttpClient.h */,
 				CD3168FA1D5606ED009935F3 /* HLHttpClient.m */,
 				CD3169111D5606ED009935F3 /* HLSessionClient.h */,
@@ -303,6 +306,7 @@
 				CD3169321D5606ED009935F3 /* HLMatch.h in Headers */,
 				CD31693E1D5606ED009935F3 /* HLPurchaseVerification.h in Headers */,
 				CD3169481D5606ED009935F3 /* NSData+GZIP.h in Headers */,
+				136035111D5E3371002AFF78 /* HeroicLabs.h in Headers */,
 				CD3169211D5606ED009935F3 /* HLDefaultRequestRetryHandler.h in Headers */,
 				CD3169381D5606ED009935F3 /* HLMessage.h in Headers */,
 				CD3169251D5606ED009935F3 /* HLGameCenterCredentials.h in Headers */,
@@ -565,7 +569,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEFINES_MODULE = NO;
+				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -588,7 +592,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEFINES_MODULE = NO;
+				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";


### PR DESCRIPTION
- Add umbrella header HeroicLabs.h
- Change DEFINES_MODULE setting in Xcode project

By defining a module, the framework can be imported in Swift without a bridging header.